### PR TITLE
Pending button tweaks

### DIFF
--- a/server/public/styles/style.css
+++ b/server/public/styles/style.css
@@ -379,3 +379,7 @@ textarea {
 .editComments {
   bottom: 2px;
 }
+
+.md-button.md-raised:hover {
+  background: lightgrey !important;
+}

--- a/server/public/styles/style.css
+++ b/server/public/styles/style.css
@@ -383,3 +383,11 @@ textarea {
 .md-button.md-raised:hover {
   background: lightgrey !important;
 }
+
+.pending-list-name-field {
+  text-align: left;
+}
+
+.pending-list-date-field {
+  text-align: right;
+}

--- a/server/public/views/templates/dashboard.html
+++ b/server/public/views/templates/dashboard.html
@@ -36,8 +36,8 @@
         ng-value="listing.id">
         <md-button>
           <div layout="row">
-            <div flex="50">{{listing.firstname}} {{listing.lastname}}</div>
-            <div flex="50">{{listing.startdate | date: 'MMMM d, y'}}</div>
+            <div flex="50" class="pending-list-name-field">{{listing.firstname}} {{listing.lastname}}</div>
+            <div flex="50" class="pending-list-date-field">{{listing.startdate | date: 'MMMM d, y'}}</div>
           </div>
         </md-button>
       </md-menu-item>

--- a/server/public/views/templates/dashboard.html
+++ b/server/public/views/templates/dashboard.html
@@ -27,7 +27,7 @@
     </md-card>
   </div>
   <md-menu ng-controller="DirectoryController as DC" ng-init="DC.getApproval()" flex layout="row" layout-align="center center">
-    <md-button class="md-raised" id="awaiting-approval-button" ng-click="$mdMenu.open()" id="notification-menu-header" layout="row" layout-align="center center">
+    <md-button class="md-raised" id="awaiting-approval-button" ng-click="DC.approval.list.length===0||$mdMenu.open()" id="notification-menu-header" layout="row" layout-align="center center">
       <span ng-if="DC.approval.list.length>0">Pending intake forms<md-icon md-svg-src="/img/ic_fiber_new_48px.svg" id="intake-button-icon"></md-icon></span>
       <span ng-if="DC.approval.list.length===0">No pending intake forms</span>
     </md-button>


### PR DESCRIPTION
-Added hover effect on all white 'md-raised' buttons on site.
-Clicking on pending survey button no longer does anything if there are no pending surveys.
-Aligned the text differently in the pending survey menu -- it's on the edge of the menu instead of the date awkwardly floating in the middle. I think it looks better.